### PR TITLE
Removed unnecessary check in move_to_next_position for CombinationsWithReplacement

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -284,13 +284,11 @@ impl<T: Ord + Clone> CombinationsWithReplacement<T> {
             if cur_position >= self.elements.len() - 1 {
                 continue;
             }
-            if index == length - 1 || cur_position < *self.positions.get(index + 1).unwrap() {
-                let next_position = cur_position + 1;
-                for i in index..length {
-                    *self.positions.get_mut(i).unwrap() = next_position;
-                }
-                return true;
+            let next_position = cur_position + 1;
+            for i in index..length {
+                *self.positions.get_mut(i).unwrap() = next_position;
             }
+            return true;
         }
         false
     }

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -282,9 +282,15 @@ impl<T: Ord + Clone> CombinationsWithReplacement<T> {
         for index in (0..self.positions.len()).rev() {
             let cur_position = *self.positions.get(index).unwrap();
             if cur_position >= self.elements.len() - 1 {
+                // We only want to advance an earlier position if all later positions are already
+                // at the final element. Otherwise, we'd advance the latest position which is not
+                // yet at the final element.
                 continue;
             }
             let next_position = cur_position + 1;
+            // We know that `cur_position` is not at the final element, and any later positions
+            // must be at the final element, so we can unconditionally set the current and any
+            // subsequent positions to `next_position`.
             for i in index..length {
                 *self.positions.get_mut(i).unwrap() = next_position;
             }


### PR DESCRIPTION
A small performance improvement opportunity I noticed :)

When iterating over the `positions` vector to find the position to start writing the `next_position` from, the current implementation of `move_to_next_position` for `CombinationsWithReplacement` checks that the candidate position is either 1) the last position in the vector or 2) less than the following position. However, `move_to_next_position` only generates non-decreasing `positions` vectors (and this check does not contribute to this). Therefore, this check will always pass and can thus safely be removed.

All tests still pass when running `cargo test`.